### PR TITLE
Use path.sep instead of "/"

### DIFF
--- a/src/utils/readInput.ts
+++ b/src/utils/readInput.ts
@@ -1,12 +1,12 @@
 import { readFileSync } from "fs"
 import * as getCallerFile from "get-caller-file"
+import * as path from "path"
 
 export const readInput = () => {
-  const file = getCallerFile()
-    .split("/")
-    .slice(0, -1)
-    .concat("input.txt")
-    .join("/")
+  const file = path.join(
+    path.dirname(getCallerFile()),
+    "input.txt"
+  );
 
   return readFileSync(file).toString()
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "target": "es2019",
     "allowJs": true,
     "strict": false,
-    "lib": ["dom", "es2019"]
+    "lib": ["dom", "es2019"],
+    "moduleResolution": "node"
   },
   "include": ["src", "examples/passThrough.ts"],
   "exclude": ["node_modules", "src/**/*.test.ts", "src/**/*.temp.ts"]


### PR DESCRIPTION
This commit fixes `readInput.ts` to use an environment agnostic separator instead of a 
hardcoded "/". In passing, refactored the code a bit to use built-in path methods whenever
possible.
