### PR TITLE
Updated Spawn Command for Windows Compatability

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -10,6 +10,6 @@ if (!days.includes(day)) {
   cp("-r", "src/template", `src/${day}`)
 }
 
-spawn("nodemon", ["-x", "ts-node", `src/${day}/index.ts`], {
+spawn(/^win/.test(process.platform) ? 'nodemon.cmd' : 'nodemon', ["-x", "ts-node", `src/${day}/index.ts`], {
   stdio: "inherit",
 })


### PR DESCRIPTION
It seems that on Windows the command executed by **_spawn_** cannot be just `nodemon` even though it works when using the command line.
Using `nodemon.cmd` when working on Windows works just fine.
